### PR TITLE
feat(brand): implement complete brand CRUD management for admin users

### DIFF
--- a/Migrations/20251026042921_AddSlugAndFieldsToBrand.Designer.cs
+++ b/Migrations/20251026042921_AddSlugAndFieldsToBrand.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TiendaProyecto.src.Infrastructure.Data;
 
@@ -10,9 +11,11 @@ using TiendaProyecto.src.Infrastructure.Data;
 namespace TiendaProyecto.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20251026042921_AddSlugAndFieldsToBrand")]
+    partial class AddSlugAndFieldsToBrand
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.9");

--- a/Migrations/20251026042921_AddSlugAndFieldsToBrand.cs
+++ b/Migrations/20251026042921_AddSlugAndFieldsToBrand.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+
+#nullable disable
+
+namespace TiendaProyecto.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSlugAndFieldsToBrand : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Brands",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "Brands",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Slug",
+                table: "Brands",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Brands",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Brands");
+
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "Brands");
+
+            migrationBuilder.DropColumn(
+                name: "Slug",
+                table: "Brands");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "Brands");
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -142,7 +142,8 @@ builder.Services.AddScoped<ICartRepository, CartRepository>();
 builder.Services.AddScoped<ICartService, CartService>();
 builder.Services.AddScoped<ICategoryRepository, CategoryRepository>();
 builder.Services.AddScoped<ICategoryService, CategoryService>();
-
+builder.Services.AddScoped<IBrandRepository, BrandRepository>();
+builder.Services.AddScoped<IBrandService, BrandService>();
 
 
 // Configurar Swagger/OpenAPI

--- a/src/API/Controllers/BrandController.cs
+++ b/src/API/Controllers/BrandController.cs
@@ -1,0 +1,95 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TiendaProyecto.src.api.Controllers;
+using TiendaProyecto.src.Application.DTO.BaseResponse;
+using TiendaProyecto.src.Application.DTO.BrandDTO;
+using TiendaProyecto.src.Application.DTO.ProductDTO;
+using TiendaProyecto.src.Application.Services.Interfaces;
+
+namespace TiendaProyecto.src.API.Controllers
+{
+    /// <summary>
+    /// Controlador para la gestión de marcas (solo administradores).
+    /// </summary>
+    [Route("api/admin/[controller]")]
+    [ApiController]
+    [Authorize(Roles = "Admin")]
+    public class BrandController : BaseController
+    {
+        private readonly IBrandService _brandService;
+
+        public BrandController(IBrandService brandService)
+        {
+            _brandService = brandService;
+        }
+
+        /// <summary>
+        /// Obtiene todas las marcas con paginación y búsqueda.
+        /// </summary>
+        /// <param name="searchParams">Parámetros de búsqueda y paginación.</param>
+        /// <returns>Lista paginada de marcas.</returns>
+        [HttpGet]
+        public async Task<IActionResult> GetAll([FromQuery] SearchParamsDTO searchParams)
+        {
+            var result = await _brandService.GetAllAsync(searchParams);
+            return Ok(new GenericResponse<ListedBrandsDTO>("Marcas obtenidas exitosamente", result));
+        }
+
+        /// <summary>
+        /// Obtiene una marca por ID.
+        /// </summary>
+        /// <param name="id">ID de la marca.</param>
+        /// <returns>Detalle de la marca.</returns>
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(int id)
+        {
+            var result = await _brandService.GetByIdAsync(id);
+            return Ok(new GenericResponse<BrandDetailDTO>("Marca obtenida exitosamente", result));
+        }
+
+        /// <summary>
+        /// Crea una nueva marca.
+        /// </summary>
+        /// <param name="createDto">Datos para crear la marca.</param>
+        /// <returns>Marca creada.</returns>
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] BrandCreateDTO createDto)
+        {
+            var result = await _brandService.CreateAsync(createDto);
+            return CreatedAtAction(nameof(GetById), new { id = result.Id },
+                new GenericResponse<BrandDetailDTO>("Marca creada exitosamente", result));
+        }
+
+        /// <summary>
+        /// Actualiza una marca existente.
+        /// </summary>
+        /// <param name="id">ID de la marca a actualizar.</param>
+        /// <param name="updateDto">Datos actualizados de la marca.</param>
+        /// <returns>Marca actualizada.</returns>
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, [FromBody] BrandUpdateDTO updateDto)
+        {
+            var result = await _brandService.UpdateAsync(id, updateDto);
+            return Ok(new GenericResponse<BrandDetailDTO>("Marca actualizada exitosamente", result));
+        }
+
+        /// <summary>
+        /// Elimina una marca.
+        /// </summary>
+        /// <param name="id">ID de la marca a eliminar.</param>
+        /// <returns>Confirmación de eliminación.</returns>
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var result = await _brandService.DeleteAsync(id);
+            if (result)
+            {
+                return Ok(new GenericResponse<object>("Marca eliminada exitosamente", null));
+            }
+            else
+            {
+                return BadRequest(new GenericResponse<object>("No se pudo eliminar la marca", null));
+            }
+        }
+    }
+}

--- a/src/Application/DTO/BrandDTO/BrandCreateDTO.cs
+++ b/src/Application/DTO/BrandDTO/BrandCreateDTO.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TiendaProyecto.src.Application.DTO.BrandDTO
+{
+    /// <summary>
+    /// DTO utilizado para crear una nueva marca.
+    /// </summary>
+    public class BrandCreateDTO
+    {
+        /// <summary>
+        /// Nombre de la marca.
+        /// </summary>
+        [Required(ErrorMessage = "El nombre de la marca es obligatorio.")]
+        [StringLength(80, MinimumLength = 2, ErrorMessage = "El nombre debe tener entre 2 y 80 caracteres.")]
+        public required string Name { get; set; }
+
+        /// <summary>
+        /// Descripción opcional de la marca.
+        /// </summary>
+        [StringLength(500, ErrorMessage = "La descripción no puede exceder los 500 caracteres.")]
+        public string? Description { get; set; }
+    }
+}

--- a/src/Application/DTO/BrandDTO/BrandDetailDTO.cs
+++ b/src/Application/DTO/BrandDTO/BrandDetailDTO.cs
@@ -1,0 +1,48 @@
+namespace TiendaProyecto.src.Application.DTO.BrandDTO
+{
+    /// <summary>
+    /// DTO que representa el detalle completo de una marca.
+    /// </summary>
+    public class BrandDetailDTO
+    {
+        /// <summary>
+        /// Identificador único de la marca.
+        /// </summary>
+        public required int Id { get; set; }
+
+        /// <summary>
+        /// Nombre de la marca.
+        /// </summary>
+        public required string Name { get; set; }
+
+        /// <summary>
+        /// Slug normalizado de la marca.
+        /// </summary>
+        public required string Slug { get; set; }
+
+        /// <summary>
+        /// Descripción de la marca.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Cantidad de productos asociados a esta marca.
+        /// </summary>
+        public required int ProductCount { get; set; }
+
+        /// <summary>
+        /// Indica si la marca está activa.
+        /// </summary>
+        public required bool IsActive { get; set; }
+
+        /// <summary>
+        /// Fecha de creación.
+        /// </summary>
+        public required DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// Fecha de última actualización.
+        /// </summary>
+        public required DateTime UpdatedAt { get; set; }
+    }
+}

--- a/src/Application/DTO/BrandDTO/BrandUpdateDTO.cs
+++ b/src/Application/DTO/BrandDTO/BrandUpdateDTO.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TiendaProyecto.src.Application.DTO.BrandDTO
+{
+    /// <summary>
+    /// DTO utilizado para actualizar una marca existente.
+    /// </summary>
+    public class BrandUpdateDTO
+    {
+        /// <summary>
+        /// Nombre de la marca.
+        /// </summary>
+        [Required(ErrorMessage = "El nombre de la marca es obligatorio.")]
+        [StringLength(80, MinimumLength = 2, ErrorMessage = "El nombre debe tener entre 2 y 80 caracteres.")]
+        public required string Name { get; set; }
+
+        /// <summary>
+        /// Descripción opcional de la marca.
+        /// </summary>
+        [StringLength(500, ErrorMessage = "La descripción no puede exceder los 500 caracteres.")]
+        public string? Description { get; set; }
+    }
+}

--- a/src/Application/DTO/BrandDTO/ListedBrandsDTO.cs
+++ b/src/Application/DTO/BrandDTO/ListedBrandsDTO.cs
@@ -1,0 +1,33 @@
+namespace TiendaProyecto.src.Application.DTO.BrandDTO
+{
+    /// <summary>
+    /// DTO que representa un listado paginado de marcas.
+    /// </summary>
+    public class ListedBrandsDTO
+    {
+        /// <summary>
+        /// Lista de marcas.
+        /// </summary>
+        public List<BrandDetailDTO> Brands { get; set; } = new List<BrandDetailDTO>();
+
+        /// <summary>
+        /// Cantidad total de marcas.
+        /// </summary>
+        public int TotalCount { get; set; }
+
+        /// <summary>
+        /// Número total de páginas disponibles.
+        /// </summary>
+        public int TotalPages { get; set; }
+
+        /// <summary>
+        /// Página actual del listado.
+        /// </summary>
+        public int CurrentPage { get; set; }
+
+        /// <summary>
+        /// Cantidad de marcas por página.
+        /// </summary>
+        public int PageSize { get; set; }
+    }
+}

--- a/src/Application/Services/Implements/BrandService.cs
+++ b/src/Application/Services/Implements/BrandService.cs
@@ -1,0 +1,178 @@
+using Mapster;
+using Serilog;
+using System.Text.RegularExpressions;
+using TiendaProyecto.src.Application.DTO.BrandDTO;
+using TiendaProyecto.src.Application.DTO.ProductDTO;
+using TiendaProyecto.src.Application.Services.Interfaces;
+using TiendaProyecto.src.Domain.Models;
+using TiendaProyecto.src.Exceptions;
+using TiendaProyecto.src.Infrastructure.Repositories.Interfaces;
+
+namespace TiendaProyecto.src.Application.Services.Implements
+{
+    /// <summary>
+    /// Servicio para la gestión de marcas.
+    /// </summary>
+    public class BrandService : IBrandService
+    {
+        private readonly IBrandRepository _brandRepository;
+        private readonly IConfiguration _configuration;
+        private readonly int _defaultPageSize;
+
+        public BrandService(IBrandRepository brandRepository, IConfiguration configuration)
+        {
+            _brandRepository = brandRepository;
+            _configuration = configuration;
+            _defaultPageSize = int.Parse(_configuration["Products:DefaultPageSize"] ?? "10");
+        }
+
+        public async Task<ListedBrandsDTO> GetAllAsync(SearchParamsDTO searchParams)
+        {
+            var (brands, totalCount) = await _brandRepository.GetAllAsync(searchParams);
+            var pageSize = searchParams.PageSize ?? _defaultPageSize;
+            var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
+
+            var brandDtos = new List<BrandDetailDTO>();
+            foreach (var brand in brands)
+            {
+                var productCount = await _brandRepository.CountProductsByBrand(brand.Id);
+                var dto = brand.Adapt<BrandDetailDTO>();
+                dto.ProductCount = productCount;
+                brandDtos.Add(dto);
+            }
+
+            return new ListedBrandsDTO
+            {
+                Brands = brandDtos,
+                TotalCount = totalCount,
+                TotalPages = totalPages,
+                CurrentPage = searchParams.PageNumber,
+                PageSize = pageSize
+            };
+        }
+
+        public async Task<BrandDetailDTO> GetByIdAsync(int id)
+        {
+            var brand = await _brandRepository.GetByIdAsync(id);
+            if (brand == null)
+            {
+                throw new NotFoundException($"Marca con ID {id} no encontrada.");
+            }
+
+            var productCount = await _brandRepository.CountProductsByBrand(id);
+            var dto = brand.Adapt<BrandDetailDTO>();
+            dto.ProductCount = productCount;
+
+            return dto;
+        }
+
+        public async Task<BrandDetailDTO> CreateAsync(BrandCreateDTO createDto)
+        {
+            // Sanitizar datos de entrada
+            var sanitizedName = SanitizeInput(createDto.Name);
+            var sanitizedDescription = !string.IsNullOrEmpty(createDto.Description)
+                ? SanitizeInput(createDto.Description)
+                : null;
+
+            // Verificar unicidad del nombre
+            if (await _brandRepository.ExistsByNameAsync(sanitizedName))
+            {
+                throw new ConflictException($"Ya existe una marca con el nombre '{sanitizedName}'.");
+            }
+
+            // Generar slug único
+            var slug = await _brandRepository.GenerateUniqueSlugAsync(sanitizedName);
+
+            var brand = new Brand
+            {
+                Name = sanitizedName,
+                Slug = slug,
+                Description = sanitizedDescription,
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            var createdBrand = await _brandRepository.CreateAsync(brand);
+            Log.Information("Marca creada: {@Brand}", createdBrand);
+
+            var dto = createdBrand.Adapt<BrandDetailDTO>();
+            dto.ProductCount = 0;
+
+            return dto;
+        }
+
+        public async Task<BrandDetailDTO> UpdateAsync(int id, BrandUpdateDTO updateDto)
+        {
+            var brand = await _brandRepository.GetByIdAsync(id);
+            if (brand == null)
+            {
+                throw new NotFoundException($"Marca con ID {id} no encontrada.");
+            }
+
+            // Sanitizar datos de entrada
+            var sanitizedName = SanitizeInput(updateDto.Name);
+            var sanitizedDescription = !string.IsNullOrEmpty(updateDto.Description)
+                ? SanitizeInput(updateDto.Description)
+                : null;
+
+            // Verificar unicidad del nombre (excluyendo la marca actual)
+            if (await _brandRepository.ExistsByNameAsync(sanitizedName, id))
+            {
+                throw new ConflictException($"Ya existe otra marca con el nombre '{sanitizedName}'.");
+            }
+
+            // Generar nuevo slug si el nombre cambió
+            string newSlug = brand.Slug;
+            if (brand.Name != sanitizedName)
+            {
+                newSlug = await _brandRepository.GenerateUniqueSlugAsync(sanitizedName, id);
+            }
+
+            brand.Name = sanitizedName;
+            brand.Slug = newSlug;
+            brand.Description = sanitizedDescription;
+
+            var updatedBrand = await _brandRepository.UpdateAsync(brand);
+            var productCount = await _brandRepository.CountProductsByBrand(id);
+
+            var dto = updatedBrand.Adapt<BrandDetailDTO>();
+            dto.ProductCount = productCount;
+
+            return dto;
+        }
+
+        public async Task<bool> DeleteAsync(int id)
+        {
+            var brand = await _brandRepository.GetByIdAsync(id);
+            if (brand == null)
+            {
+                throw new NotFoundException($"Marca con ID {id} no encontrada.");
+            }
+
+            // Verificar si hay productos asociados
+            var productCount = await _brandRepository.CountProductsByBrand(id);
+            if (productCount > 0)
+            {
+                throw new ConflictException(
+                    $"No se puede eliminar la marca '{brand.Name}' porque tiene {productCount} producto(s) asociado(s). " +
+                    "Elimine o reasigne los productos antes de eliminar la marca."
+                );
+            }
+
+            return await _brandRepository.DeleteAsync(id);
+        }
+
+        private static string SanitizeInput(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                return string.Empty;
+
+            // Remover HTML y scripts
+            var sanitized = Regex.Replace(input, @"<[^>]*>", string.Empty);
+            sanitized = Regex.Replace(sanitized, @"<script[^>]*>.*?</script>", string.Empty, RegexOptions.IgnoreCase);
+
+            return sanitized.Trim();
+        }
+    }
+}

--- a/src/Application/Services/Interfaces/IBrandService.cs
+++ b/src/Application/Services/Interfaces/IBrandService.cs
@@ -1,0 +1,36 @@
+using TiendaProyecto.src.Application.DTO.BrandDTO;
+using TiendaProyecto.src.Application.DTO.ProductDTO;
+
+namespace TiendaProyecto.src.Application.Services.Interfaces
+{
+    /// <summary>
+    /// Interfaz para el servicio de marcas.
+    /// </summary>
+    public interface IBrandService
+    {
+        /// <summary>
+        /// Obtiene todas las marcas con paginación.
+        /// </summary>
+        Task<ListedBrandsDTO> GetAllAsync(SearchParamsDTO searchParams);
+
+        /// <summary>
+        /// Obtiene una marca por ID.
+        /// </summary>
+        Task<BrandDetailDTO> GetByIdAsync(int id);
+
+        /// <summary>
+        /// Crea una nueva marca.
+        /// </summary>
+        Task<BrandDetailDTO> CreateAsync(BrandCreateDTO createDto);
+
+        /// <summary>
+        /// Actualiza una marca existente.
+        /// </summary>
+        Task<BrandDetailDTO> UpdateAsync(int id, BrandUpdateDTO updateDto);
+
+        /// <summary>
+        /// Elimina una marca.
+        /// </summary>
+        Task<bool> DeleteAsync(int id);
+    }
+}

--- a/src/Domain/Models/Brand.cs
+++ b/src/Domain/Models/Brand.cs
@@ -18,8 +18,33 @@ namespace TiendaProyecto.src.Domain.Models
         public required string Name { get; set; }
 
         /// <summary>
+        /// Slug normalizado para URLs amigables.
+        /// </summary>
+        public required string Slug { get; set; }
+
+        /// <summary>
+        /// Descripción opcional de la marca.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Indica si la marca está activa.
+        /// </summary>
+        public bool IsActive { get; set; } = true;
+
+        /// <summary>
         /// Fecha de creación de la marca.
         /// </summary>
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// Fecha de última actualización.
+        /// </summary>
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// Productos asociados a esta marca.
+        /// </summary>
+        public ICollection<Product> Products { get; set; } = new List<Product>();
     }
 }

--- a/src/Infrastructure/Data/DataSeeder.Cs
+++ b/src/Infrastructure/Data/DataSeeder.Cs
@@ -70,11 +70,13 @@ namespace TiendaProyecto.src.Infrastructure.Data
                 if (!await context.Brands.AnyAsync())
                 {
                     var brands = new List<Brand>
-                        {
-                            new Brand { Name = "Sony" },
-                            new Brand { Name = "Apple" },
-                            new Brand { Name = "HP" }
-                        };
+                    {
+                        new Brand { Name = "Sony", Slug = "sony" },
+                        new Brand { Name = "Apple", Slug = "apple" },
+                        new Brand { Name = "HP", Slug = "hp" },
+                        new Brand { Name = "Samsung", Slug = "samsung" },
+                        new Brand { Name = "Nike", Slug = "nike" }
+                    };
                     await context.Brands.AddRangeAsync(brands);
                     await context.SaveChangesAsync();
                     Log.Information("Marcas creadas con éxito.");

--- a/src/Infrastructure/Repositories/Implements/BrandRepository.cs
+++ b/src/Infrastructure/Repositories/Implements/BrandRepository.cs
@@ -1,0 +1,175 @@
+using Microsoft.EntityFrameworkCore;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using TiendaProyecto.src.Application.DTO.ProductDTO;
+using TiendaProyecto.src.Domain.Models;
+using TiendaProyecto.src.Infrastructure.Data;
+using TiendaProyecto.src.Infrastructure.Repositories.Interfaces;
+
+namespace TiendaProyecto.src.Infrastructure.Repositories.Implements
+{
+    /// <summary>
+    /// Implementación del repositorio de marcas.
+    /// </summary>
+    public class BrandRepository : IBrandRepository
+    {
+        private readonly DataContext _context;
+        private readonly IConfiguration _configuration;
+        private readonly int _defaultPageSize;
+
+        public BrandRepository(DataContext context, IConfiguration configuration)
+        {
+            _context = context;
+            _configuration = configuration;
+            _defaultPageSize = int.Parse(_configuration["Products:DefaultPageSize"] ?? "10");
+        }
+
+        public async Task<(IEnumerable<Brand> brands, int totalCount)> GetAllAsync(SearchParamsDTO searchParams)
+        {
+            var query = _context.Brands
+                .Where(b => b.IsActive)
+                .AsNoTracking();
+
+            // Búsqueda por término
+            if (!string.IsNullOrWhiteSpace(searchParams.SearchTerm))
+            {
+                var searchTerm = searchParams.SearchTerm.Trim().ToLower();
+                query = query.Where(b =>
+                    b.Name.ToLower().Contains(searchTerm) ||
+                    (b.Description != null && b.Description.ToLower().Contains(searchTerm)));
+            }
+
+            var totalCount = await query.CountAsync();
+
+            // Paginación
+            var pageSize = searchParams.PageSize ?? _defaultPageSize;
+            var brands = await query
+                .OrderBy(b => b.Name)
+                .Skip((searchParams.PageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+
+            return (brands, totalCount);
+        }
+
+        public async Task<Brand?> GetByIdAsync(int id)
+        {
+            return await _context.Brands
+                .Include(b => b.Products.Where(p => p.IsAvailable))
+                .AsNoTracking()
+                .FirstOrDefaultAsync(b => b.Id == id && b.IsActive);
+        }
+
+        public async Task<Brand?> GetBySlugAsync(string slug)
+        {
+            return await _context.Brands
+                .Include(b => b.Products.Where(p => p.IsAvailable))
+                .AsNoTracking()
+                .FirstOrDefaultAsync(b => b.Slug == slug && b.IsActive);
+        }
+
+        public async Task<bool> ExistsByNameAsync(string name, int? excludeId = null)
+        {
+            var query = _context.Brands.Where(b => b.Name.ToLower() == name.ToLower() && b.IsActive);
+
+            if (excludeId.HasValue)
+                query = query.Where(b => b.Id != excludeId.Value);
+
+            return await query.AnyAsync();
+        }
+
+        public async Task<bool> ExistsBySlugAsync(string slug, int? excludeId = null)
+        {
+            var query = _context.Brands.Where(b => b.Slug == slug && b.IsActive);
+
+            if (excludeId.HasValue)
+                query = query.Where(b => b.Id != excludeId.Value);
+
+            return await query.AnyAsync();
+        }
+
+        public async Task<Brand> CreateAsync(Brand brand)
+        {
+            _context.Brands.Add(brand);
+            await _context.SaveChangesAsync();
+            return brand;
+        }
+
+        public async Task<Brand> UpdateAsync(Brand brand)
+        {
+            brand.UpdatedAt = DateTime.UtcNow;
+            _context.Brands.Update(brand);
+            await _context.SaveChangesAsync();
+            return brand;
+        }
+
+        public async Task<bool> DeleteAsync(int id)
+        {
+            var brand = await _context.Brands.FindAsync(id);
+            if (brand == null) return false;
+
+            brand.IsActive = false;
+            brand.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
+        public async Task<int> CountProductsByBrand(int brandId)
+        {
+            return await _context.Products
+                .Where(p => p.BrandId == brandId && p.IsAvailable)
+                .CountAsync();
+        }
+
+        public async Task<string> GenerateUniqueSlugAsync(string name, int? excludeId = null)
+        {
+            var baseSlug = NormalizeSlug(name);
+            var slug = baseSlug;
+            var counter = 1;
+
+            while (await ExistsBySlugAsync(slug, excludeId))
+            {
+                slug = $"{baseSlug}-{counter}";
+                counter++;
+            }
+
+            return slug;
+        }
+
+        private static string NormalizeSlug(string input)
+        {
+            // Convertir a minúsculas
+            var slug = input.ToLowerInvariant();
+
+            // Remover acentos
+            slug = RemoveAccents(slug);
+
+            // Reemplazar espacios y caracteres especiales con guiones
+            slug = Regex.Replace(slug, @"[^a-z0-9\s-]", "");
+            slug = Regex.Replace(slug, @"[\s-]+", "-").Trim('-');
+
+            return slug;
+        }
+
+        private static string RemoveAccents(string text)
+        {
+            // Normalizar el texto para separar caracteres base de los acentos
+            var normalizedString = text.Normalize(NormalizationForm.FormD);
+            var stringBuilder = new StringBuilder();
+
+            foreach (var c in normalizedString)
+            {
+                var unicodeCategory = CharUnicodeInfo.GetUnicodeCategory(c);
+                // Solo mantener caracteres que NO sean marcas diacríticas (acentos)
+                if (unicodeCategory != UnicodeCategory.NonSpacingMark)
+                {
+                    stringBuilder.Append(c);
+                }
+            }
+
+            // Normalizar de vuelta
+            return stringBuilder.ToString().Normalize(NormalizationForm.FormC);
+        }
+    }
+}

--- a/src/Infrastructure/Repositories/Interfaces/IBrandRepository.cs
+++ b/src/Infrastructure/Repositories/Interfaces/IBrandRepository.cs
@@ -1,0 +1,61 @@
+using TiendaProyecto.src.Application.DTO.ProductDTO;
+using TiendaProyecto.src.Domain.Models;
+
+namespace TiendaProyecto.src.Infrastructure.Repositories.Interfaces
+{
+    /// <summary>
+    /// Interfaz para el repositorio de marcas.
+    /// </summary>
+    public interface IBrandRepository
+    {
+        /// <summary>
+        /// Obtiene todas las marcas con paginación y búsqueda.
+        /// </summary>
+        Task<(IEnumerable<Brand> brands, int totalCount)> GetAllAsync(SearchParamsDTO searchParams);
+
+        /// <summary>
+        /// Obtiene una marca por ID.
+        /// </summary>
+        Task<Brand?> GetByIdAsync(int id);
+
+        /// <summary>
+        /// Obtiene una marca por slug.
+        /// </summary>
+        Task<Brand?> GetBySlugAsync(string slug);
+
+        /// <summary>
+        /// Verifica si existe una marca con el nombre especificado.
+        /// </summary>
+        Task<bool> ExistsByNameAsync(string name, int? excludeId = null);
+
+        /// <summary>
+        /// Verifica si existe una marca con el slug especificado.
+        /// </summary>
+        Task<bool> ExistsBySlugAsync(string slug, int? excludeId = null);
+
+        /// <summary>
+        /// Crea una nueva marca.
+        /// </summary>
+        Task<Brand> CreateAsync(Brand brand);
+
+        /// <summary>
+        /// Actualiza una marca existente.
+        /// </summary>
+        Task<Brand> UpdateAsync(Brand brand);
+
+        /// <summary>
+        /// Elimina una marca (soft delete).
+        /// </summary>
+        Task<bool> DeleteAsync(int id);
+
+        /// <summary>
+        /// Cuenta productos asociados a una marca.
+        /// </summary>
+        Task<int> CountProductsByBrand(int brandId);
+
+        /// <summary>
+        /// Genera un slug único basado en el nombre.
+        /// </summary>
+        Task<string> GenerateUniqueSlugAsync(string name, int? excludeId = null);
+    }
+}


### PR DESCRIPTION
## Create brand crud for admin
- Add brand DTOs (BrandCreateDTO, BrandUpdateDTO, BrandDetailDTO, ListedBrandsDTO)
- Implement IBrandRepository and BrandRepository
- Add unique slug generation with normalization and accent removal for brands
- Include soft delete functionality and product count validation
- Implement IBrandService and BrandService
- Add input sanitization and conflict handling for duplicate brand names
- Create BrandController with admin role authorization
- Update Brand domain model with slug
- Register brand services in dependency injection container
- Update DataSeeder to include brand slugs for compatibility
- Update ProductRepository to handle brand slug generation