### PR TITLE
fix(users): Fix pagination, state filtering, and sorting in the user …

### DIFF
--- a/src/Application/DTO/ProductDTO/SearchParamsDTO.cs
+++ b/src/Application/DTO/ProductDTO/SearchParamsDTO.cs
@@ -12,9 +12,9 @@ namespace TiendaProyecto.src.Application.DTO.ProductDTO
     public class SearchParamsDTO
     {
         /// <summary>
-        /// Número de página que se desea consultar.
+        /// Número de página que se desea consultar. Por defecto es 1.
         /// </summary>
-        public int PageNumber { get; set; } = 1;
+        public int? PageNumber { get; set; }
 
         /// <summary>
         /// Tamaño de página que se desea consultar.

--- a/src/Application/Services/Implements/BrandService.cs
+++ b/src/Application/Services/Implements/BrandService.cs
@@ -28,8 +28,17 @@ namespace TiendaProyecto.src.Application.Services.Implements
 
         public async Task<ListedBrandsDTO> GetAllAsync(SearchParamsDTO searchParams)
         {
-            var (brands, totalCount) = await _brandRepository.GetAllAsync(searchParams);
+            // Establecer valores por defecto
+            var pageNumber = searchParams.PageNumber ?? 1;
+            if (pageNumber < 1) pageNumber = 1;
+            
             var pageSize = searchParams.PageSize ?? _defaultPageSize;
+            
+            // Asignar valores validados
+            searchParams.PageNumber = pageNumber;
+            searchParams.PageSize = pageSize;
+            
+            var (brands, totalCount) = await _brandRepository.GetAllAsync(searchParams);
             var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
 
             var brandDtos = new List<BrandDetailDTO>();
@@ -46,7 +55,7 @@ namespace TiendaProyecto.src.Application.Services.Implements
                 Brands = brandDtos,
                 TotalCount = totalCount,
                 TotalPages = totalPages,
-                CurrentPage = searchParams.PageNumber,
+                CurrentPage = pageNumber,
                 PageSize = pageSize
             };
         }

--- a/src/Application/Services/Implements/CategoryService.cs
+++ b/src/Application/Services/Implements/CategoryService.cs
@@ -33,8 +33,17 @@ namespace TiendaProyecto.src.Application.Services.Implements
 
         public async Task<ListedCategoriesDTO> GetAllAsync(SearchParamsDTO searchParams)
         {
-            var (categories, totalCount) = await _categoryRepository.GetAllAsync(searchParams);
+            // Establecer valores por defecto
+            var pageNumber = searchParams.PageNumber ?? 1;
+            if (pageNumber < 1) pageNumber = 1;
+            
             var pageSize = searchParams.PageSize ?? _defaultPageSize;
+            
+            // Asignar valores validados
+            searchParams.PageNumber = pageNumber;
+            searchParams.PageSize = pageSize;
+            
+            var (categories, totalCount) = await _categoryRepository.GetAllAsync(searchParams);
             var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
 
             var categoryDtos = new List<CategoryDetailDTO>();
@@ -51,7 +60,7 @@ namespace TiendaProyecto.src.Application.Services.Implements
                 Categories = categoryDtos,
                 TotalCount = totalCount,
                 TotalPages = totalPages,
-                CurrentPage = searchParams.PageNumber,
+                CurrentPage = pageNumber,
                 PageSize = pageSize
             };
         }

--- a/src/Application/Services/Implements/OrderService.cs
+++ b/src/Application/Services/Implements/OrderService.cs
@@ -154,20 +154,25 @@ namespace TiendaProyecto.src.Application.Services.Implements
         /// </summary>
         public async Task<ListedOrderDetailDTO> GetByUserIdAsync(SearchParamsDTO searchParams, int userId)
         {
-            if (searchParams.PageNumber <= 0)
+            var pageNumber = searchParams.PageNumber ?? 1;
+            if (pageNumber <= 0)
             {
-                searchParams.PageNumber = 1;
+                pageNumber = 1;
             }
 
             int pageSize = searchParams.PageSize ?? _defaultPageSize;
             int maxPageSize = 100;
             if (pageSize > maxPageSize) pageSize = maxPageSize;
 
+            // Asignar valores validados
+            searchParams.PageNumber = pageNumber;
+            searchParams.PageSize = pageSize;
+
             // delegar a orderrepository
             var (orders, totalCount) = await _orderRepository.GetByUserIdAsync(searchParams, userId);
 
             var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
-            var currentPage = searchParams.PageNumber > totalPages && totalPages > 0 ? totalPages : searchParams.PageNumber;
+            var currentPage = pageNumber > totalPages && totalPages > 0 ? totalPages : pageNumber;
 
             var dto = new ListedOrderDetailDTO
             {
@@ -204,11 +209,16 @@ namespace TiendaProyecto.src.Application.Services.Implements
         /// </summary>
         public async Task<ListedOrdersForAdminDTO> GetAllAsync(SearchParamsDTO searchParams)
         {
-            if (searchParams.PageNumber <= 0) searchParams.PageNumber = 1;
+            var pageNumber = searchParams.PageNumber ?? 1;
+            if (pageNumber <= 0) pageNumber = 1;
 
             int pageSize = searchParams.PageSize ?? _defaultPageSize;
             int maxPageSize = 100;
             if (pageSize > maxPageSize) pageSize = maxPageSize;
+
+            // Asignar valores validados
+            searchParams.PageNumber = pageNumber;
+            searchParams.PageSize = pageSize;
 
             // Ordenamiento seguro: whitelist
             var allowedOrderFields = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "createdAt", "total" };
@@ -221,7 +231,7 @@ namespace TiendaProyecto.src.Application.Services.Implements
             var (orders, totalCount) = await _orderRepository.GetAllAsync(searchParams);
 
             var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
-            var currentPage = searchParams.PageNumber > totalPages && totalPages > 0 ? totalPages : searchParams.PageNumber;
+            var currentPage = pageNumber > totalPages && totalPages > 0 ? totalPages : pageNumber;
 
             var dto = new ListedOrdersForAdminDTO
             {

--- a/src/Application/Services/Implements/UserAdminService.cs
+++ b/src/Application/Services/Implements/UserAdminService.cs
@@ -36,12 +36,17 @@ namespace TiendaProyecto.src.Application.Services.Implements
 
         public async Task<ListedUsersForAdminDTO> GetUsersAsync(UserSearchParamsDTO searchParams)
         {
-            // Validar parámetros de entrada
-            if (searchParams.PageNumber <= 0)
-                searchParams.PageNumber = 1;
+            // Validar parámetros de entrada - establecer valores por defecto
+            var pageNumber = searchParams.PageNumber ?? 1;
+            if (pageNumber <= 0)
+                pageNumber = 1;
 
             var pageSize = searchParams.PageSize ?? _defaultPageSize;
             if (pageSize > 100) pageSize = 100; // Límite máximo
+
+            // Asignar valores validados al objeto searchParams
+            searchParams.PageNumber = pageNumber;
+            searchParams.PageSize = pageSize;
 
             // Validar ordenamiento
             var allowedOrderFields = new[] { "createdAt", "lastLogin", "email" };
@@ -70,7 +75,7 @@ namespace TiendaProyecto.src.Application.Services.Implements
                 Users = userDtos,
                 TotalCount = totalCount,
                 TotalPages = totalPages,
-                CurrentPage = searchParams.PageNumber,
+                CurrentPage = pageNumber,
                 PageSize = pageSize
             };
         }

--- a/src/Infrastructure/Repositories/Implements/BrandRepository.cs
+++ b/src/Infrastructure/Repositories/Implements/BrandRepository.cs
@@ -43,10 +43,11 @@ namespace TiendaProyecto.src.Infrastructure.Repositories.Implements
             var totalCount = await query.CountAsync();
 
             // Paginación
+            var pageNumber = searchParams.PageNumber ?? 1;
             var pageSize = searchParams.PageSize ?? _defaultPageSize;
             var brands = await query
                 .OrderBy(b => b.Name)
-                .Skip((searchParams.PageNumber - 1) * pageSize)
+                .Skip((pageNumber - 1) * pageSize)
                 .Take(pageSize)
                 .ToListAsync();
 

--- a/src/Infrastructure/Repositories/Implements/CategoryRepository.cs
+++ b/src/Infrastructure/Repositories/Implements/CategoryRepository.cs
@@ -43,10 +43,11 @@ namespace TiendaProyecto.src.Infrastructure.Repositories.Implements
             var totalCount = await query.CountAsync();
 
             // Paginación
+            var pageNumber = searchParams.PageNumber ?? 1;
             var pageSize = searchParams.PageSize ?? _defaultPageSize;
             var categories = await query
                 .OrderBy(c => c.Name)
-                .Skip((searchParams.PageNumber - 1) * pageSize)
+                .Skip((pageNumber - 1) * pageSize)
                 .Take(pageSize)
                 .ToListAsync();
 

--- a/src/Infrastructure/Repositories/Implements/OrderRepository.cs
+++ b/src/Infrastructure/Repositories/Implements/OrderRepository.cs
@@ -93,7 +93,7 @@ namespace TiendaProyecto.src.Infrastructure.Repositories.Implements
 
             // Normalizar pageNumber y limitar pageSize al máximo configurado
             int pageSize = searchParams.PageSize ?? _defaultPageSize;
-            int pageNumber = Math.Max(1, searchParams.PageNumber);
+            int pageNumber = Math.Max(1, searchParams.PageNumber ?? 1);
 
             // Orden por createdAt desc por defecto
             if (!string.IsNullOrWhiteSpace(searchParams.OrderBy))
@@ -182,7 +182,7 @@ namespace TiendaProyecto.src.Infrastructure.Repositories.Implements
 
             // Normalizar pageNumber y limitar pageSize al máximo configurado
             int pageSize = searchParams.PageSize ?? _defaultPageSize;
-            int pageNumber = Math.Max(1, searchParams.PageNumber);
+            int pageNumber = Math.Max(1, searchParams.PageNumber ?? 1);
 
             // Ordenamiento seguro (whitelist)
             var orderBy = (searchParams.OrderBy ?? "createdAt").Trim().ToLower();


### PR DESCRIPTION
## corregir paginación, filtrado por estado y ordenamiento en listado de usuarios

- Make PageNumber optional with a default value of 1
- Update SearchParamsDTO to accept nullable PageNumbers
- Modify UserRepository to filter state in memory (avoids LINQ errors with DateTimeOffset in SQLite)
- Fix the llowedOrderFields array to match lowercase values
- Apply the same null coalescing pattern to services and repositories (Order, Product, Brand, Category)
- Resolve LINQ translation errors when filtering by state (active/blocked)

Fixes: Blocked/active state now works correctly
Fixes: Sorting by createdAt and lastLogin works with case-insensitive methods
Fixes: PageNumber is now optional in all listing requests